### PR TITLE
OS Architecture check and installation path change

### DIFF
--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -1,12 +1,12 @@
 #NOTE: Please remove any commented lines to tidy up prior to releasing the package, including this one
 
 $packageName = 'zabbix-agent' # arbitrary name for the package, used in messages
-$installDir = Join-Path $env:ProgramFiles "Zabbix Agent"
+$installDir = "C:\Program Files\Zabbix Agent"
 
 $url = 'http://www.zabbix.com/downloads/2.0.6/zabbix_agents_2.0.6.win.zip' # download url
 $url64 = $url # 64bit URL here or just use the same as $url
 
-$is64bit = [System.IntPtr]::Size -eq 8
+$is64bit = (Get-WmiObject -Class Win32_OperatingSystem | Select-Object OSArchitecture) -match '64'
 
 $service = Get-WmiObject -Class Win32_Service -Filter "Name='Zabbix Agent'"
 

--- a/zabbix-agent.nuspec
+++ b/zabbix-agent.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>zabbix-agent</id>
     <title>zabbix-agent</title>
-    <version>2.0.6.10</version>
+    <version>2.0.6.11</version>
     <authors>Zabbix</authors>
     <owners>Guilhem Lettron</owners>
     <summary>zabbix</summary>


### PR DESCRIPTION
In certain circumstances chocolatey will install x86 version of zabbix
agent on 64-bit OS. For example running installation from 32-bit cmd or
using chocolatey like package provider for puppet who will execute
install from 32-bit cmd. In this case you get 32-bit agent running in
64-bit environment and unable to monitor 64-bit perfomance counters. Also
there is no need for "C:\Program Files (x86)" install folder as we have
separate version for each architecure.
