### PR TITLE
Updated install path

### DIFF
--- a/tools/chocolateyUninstall.ps1
+++ b/tools/chocolateyUninstall.ps1
@@ -1,5 +1,5 @@
 $package = "zabbix-agent"
-$installDir = Join-Path $env:ProgramFiles "Zabbix Agent"
+$installDir = "C:\Program Files\Zabbix Agent"
 
 try
 {


### PR DESCRIPTION
As we changed installed path in install script to always be in "C:\Program Files" directory we need to mirror this changes in uninstall script also.
