### PR TITLE
Update version to 3.4.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,16 @@
 ﻿# zabbix-agent-chocolatey
-This package installs the Zabbix agent using the pre-compiled files from [Zabbix SIA](zabbix.com).
-Executables are placed in `$env:ProgramFiles\Zabbix Agent` which is generally
-`C:\Program Files\Zabbix Agent`. The `zabbix_agentd.conf` file is stored in `$env:ProgramData\zabbix`.
-On Windows 7 and up this is generally `C:\ProgramData\zabbix`. When new versions are installed the config
-is not overwritten but rather the version number of the new file is appended to the name. For example,
-if version 2.2.1 is installed and then upgraded to version 2.4.4 you will find the sample 2.4.4 config
-files saved as `zabbix_agentd-2.4.4.conf.`
+This package installs the Zabbix agent using the pre-compiled files from [Zabbix SIA](https://www.zabbix.com/).
 
-The source for this Chocolatey package can be found on [GitHub](https://github.com/zabbix/zabbix-agent-chocolatey).
-Please also file any issues you find using the project's [Issue tracker](https://github.com/zabbix/zabbix-agent-chocolatey/issues).
+Executables are placed in `%ProgramFiles%\Zabbix Agent` and the zabbix_agentd.conf file is stored in `%ProgramData%\zabbix`. When new versions of the agent are installed, the config is not overwritten but rather the version number of the new file is appended to the name. For example, if version 3.2.0 is installed and then upgraded to version 3.4.6 you will find the sample 3.4.6 config files saved as “zabbix_agentd-3.4.6.conf”.
+
+The source code for this Chocolatey package can be found on [GitHub](https://github.com/zabbix/zabbix-agent-chocolatey). Please file any issues you find in the project's [Issue tracker](https://github.com/zabbix/zabbix-agent-chocolatey/issues).
+
 
 
 ## Release Notes
 
 
-#### 2018-01-30 Release 3.4.6
+#### 2018-05-25 Release 3.4.6
 * Bumped up to Zabbix 3.4.6
 * Fix logo for nuspec config
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Please also file any issues you find using the project's [Issue tracker](https:/
 ## Release Notes
 
 
+#### 2018-01-30 Release 3.4.6
+* Bumped up to Zabbix 3.4.6
+* Fix logo for nuspec config
+
 #### 2017-03-01 Release 3.2.0
 * Bumped up to Zabbix 3.2.0
 * Updated logo

--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -1,9 +1,9 @@
-﻿$version        = '3.2.0'
+﻿$version        = '3.4.6'
 $id             = 'zabbix-agent'
 $title          = 'Zabbix Agent'
 $url            = "https://www.zabbix.com/downloads/$version/zabbix_agents_$version.win.zip"
 $url64          = $url
-$checksum       = "c975565c2395575bf929582e52a8f31d"
+$checksum       = "7ca9e6d059032d9d5b6c49a853850bc9"
 $checksumType   = "md5"
 $checksum64     = $checksum
 $checksumType64 = $checksumType

--- a/zabbix-agent.nuspec
+++ b/zabbix-agent.nuspec
@@ -13,7 +13,7 @@
     <title>Zabbix Agent</title>
     <authors>Zabbix SIA</authors>
     <projectUrl>http://www.zabbix.com</projectUrl>
-    <iconUrl>https://cdn.rawgit.com/zabbix/zabbix-agent-chocolatey/3.2.0/logo/zabbix_logo_500x131.png</iconUrl>
+    <iconUrl>https://raw.githubusercontent.com/zabbix/zabbix-agent-chocolatey/master/logo/zabbix_logo_500x131.png</iconUrl>
     <copyright>GPL v2</copyright>
     <licenseUrl>http://www.zabbix.com/license.php</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -34,6 +34,10 @@ The source for this Chocolatey package can be found on [GitHub](https://github.c
 Please also file any issues you find using the project's [Issue tracker](https://github.com/zabbix/zabbix-agent-chocolatey/issues).
     </description>
     <releaseNotes>
+#### 2018-01-30 Release 3.4.6
+* Bumped up to Zabbix 3.4.6
+* Fix logo for nuspec config
+
 #### 2017-03-01 Release 3.2.0
 * Bumped up to Zabbix 3.2.0
 * Updated logo

--- a/zabbix-agent.nuspec
+++ b/zabbix-agent.nuspec
@@ -4,7 +4,7 @@
   <metadata>
     <!-- == PACKAGE SPECIFIC SECTION == -->
     <id>zabbix-agent</id>
-    <version>3.2.0</version>
+    <version>3.4.6</version>
     <packageSourceUrl>https://github.com/zabbix/zabbix-agent-chocolatey</packageSourceUrl>
     <owners>Gene Liverman</owners>
     <!-- ============================== -->
@@ -12,29 +12,25 @@
     <!-- == SOFTWARE SPECIFIC SECTION == -->
     <title>Zabbix Agent</title>
     <authors>Zabbix SIA</authors>
-    <projectUrl>http://www.zabbix.com</projectUrl>
+    <projectUrl>https://www.zabbix.com/</projectUrl>
     <iconUrl>https://raw.githubusercontent.com/zabbix/zabbix-agent-chocolatey/master/logo/zabbix_logo_500x131.png</iconUrl>
     <copyright>GPL v2</copyright>
-    <licenseUrl>http://www.zabbix.com/license.php</licenseUrl>
+    <licenseUrl>https://www.zabbix.com/license</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <docsUrl>http://www.zabbix.com/manuals</docsUrl>
-    <mailingListUrl>https://lists.sourceforge.net/lists/listinfo/zabbix-users</mailingListUrl>
+    <docsUrl>https://www.zabbix.com/manuals</docsUrl>
+    <mailingListUrl>https://sourceforge.net/projects/zabbix/lists/zabbix-users</mailingListUrl>
     <tags>zabbix monitoring</tags>
-    <summary>The Zabbix agent is used in conjunction with a Zabbix Server to for monitoring a system</summary>
+    <summary>The Zabbix agent is used in conjunction with a Zabbix Server to for monitoring a system.</summary>
     <description>
-This package installs the Zabbix agent using the pre-compiled files from [Zabbix SIA](zabbix.com).
-Executables are placed in `$env:ProgramFiles\Zabbix Agent` which is generally
-`C:\Program Files\Zabbix Agent`. The `zabbix_agentd.conf` file is stored in `$env:ProgramData\zabbix`.
-On Windows 7 and up this is generally `C:\ProgramData\zabbix`. When new versions are installed the config
-is not overwritten but rather the version number of the new file is appended to the name. For example,
-if version 3.0.4 is installed and then upgraded to version 3.2.0 you will find the sample 3.2.0 config
-files saved as `zabbix_agentd-3.2.0.conf.`
+This package installs the Zabbix agent using the pre-compiled files from [Zabbix SIA](https://www.zabbix.com/).
 
-The source for this Chocolatey package can be found on [GitHub](https://github.com/zabbix/zabbix-agent-chocolatey).
-Please also file any issues you find using the project's [Issue tracker](https://github.com/zabbix/zabbix-agent-chocolatey/issues).
+Executables are placed in `%ProgramFiles%\Zabbix Agent` and the zabbix_agentd.conf file is stored in `%ProgramData%\zabbix`. When new versions of the agent are installed, the config is not overwritten but rather the version number of the new file is appended to the name. For example, if version 3.2.0 is installed and then upgraded to version 3.4.6 you will find the sample 3.4.6 config files saved as “zabbix_agentd-3.4.6.conf”.
+
+The source code for this Chocolatey package can be found on [GitHub](https://github.com/zabbix/zabbix-agent-chocolatey). Please file any issues you find in the project's [Issue tracker](https://github.com/zabbix/zabbix-agent-chocolatey/issues).
+
     </description>
     <releaseNotes>
-#### 2018-01-30 Release 3.4.6
+#### 2018-05-25 Release 3.4.6
 * Bumped up to Zabbix 3.4.6
 * Fix logo for nuspec config
 


### PR DESCRIPTION
As 3.2 is no longer supported as of November 2017, we should probably get this updated to the latest version of 3.4.

Reference: https://www.zabbix.com/life_cycle_and_release_policy