### PR TITLE
change download path from win to windows

### DIFF
--- a/zabbix-agent.install/tools/chocolateyInstall.ps1
+++ b/zabbix-agent.install/tools/chocolateyInstall.ps1
@@ -3,8 +3,8 @@
 $packageName  = 'zabbix-agent.install'
 $title        = 'Zabbix Agent'
 $version      = '4.4.1'
-$url32        = "https://www.zabbix.com/downloads/$version/zabbix_agent-$version-win-i386-openssl.msi"
-$url64        = "https://www.zabbix.com/downloads/$version/zabbix_agent-$version-win-amd64-openssl.msi"
+$url32        = "https://www.zabbix.com/downloads/$version/zabbix_agent-$version-windows-i386-openssl.msi"
+$url64        = "https://www.zabbix.com/downloads/$version/zabbix_agent-$version-windows-amd64-openssl.msi"
 $checksum32   = '94c909cba0e7e9da576671dd79617c8b'
 $checksum64   = 'eb11c7d4ff01caeac7c666be8c0d4bda'
 

--- a/zabbix-agent/tools/chocolateyInstall.ps1
+++ b/zabbix-agent/tools/chocolateyInstall.ps1
@@ -1,8 +1,8 @@
 ﻿$version        = '4.4.1'
 $id             = 'zabbix-agent'
 $title          = 'Zabbix Agent'
-$url            = "https://www.zabbix.com/downloads/$version/zabbix_agents-$version-windows-i386-openssl.zip"
-$url64          = "https://www.zabbix.com/downloads/$version/zabbix_agents-$version-windows-amd64-openssl.zip"
+$url            = "https://www.zabbix.com/downloads/$version/zabbix_agent-$version-windows-i386-openssl.zip"
+$url64          = "https://www.zabbix.com/downloads/$version/zabbix_agent-$version-windows-amd64-openssl.zip"
 $checksum       = '5cf68a5ad4922385c8bc68451e04c419'
 $checksumType   = 'md5'
 $checksum64     = '03266a21522a86011eba965815354865'
@@ -40,9 +40,9 @@ try {
   }
 
   if ($is64bit) {
-    $zipFile = Join-Path $tempDir "zabbix_agents-$version-windows-amd64-openssl.zip"
+    $zipFile = Join-Path $tempDir "zabbix_agent-$version-windows-amd64-openssl.zip"
   } else {
-    $zipFile = Join-Path $tempDir "zabbix_agents-$version-windows-i386-openssl.zip"
+    $zipFile = Join-Path $tempDir "zabbix_agent-$version-windows-i386-openssl.zip"
   }
 
   Get-ChocolateyWebFile -PackageName "$id" -FileFullPath "$zipFile" -Url "$url" -Url64bit "$url64" -Checksum "$checksum" -ChecksumType "$checksumType" -Checksum64 "$checksum64" -ChecksumType64 "$checksumType64"

--- a/zabbix-agent/tools/chocolateyInstall.ps1
+++ b/zabbix-agent/tools/chocolateyInstall.ps1
@@ -1,8 +1,8 @@
 ﻿$version        = '4.4.1'
 $id             = 'zabbix-agent'
 $title          = 'Zabbix Agent'
-$url            = "https://www.zabbix.com/downloads/$version/zabbix_agents-$version-win-i386-openssl.zip"
-$url64          = "https://www.zabbix.com/downloads/$version/zabbix_agents-$version-win-amd64-openssl.zip"
+$url            = "https://www.zabbix.com/downloads/$version/zabbix_agents-$version-windows-i386-openssl.zip"
+$url64          = "https://www.zabbix.com/downloads/$version/zabbix_agents-$version-windows-amd64-openssl.zip"
 $checksum       = '5cf68a5ad4922385c8bc68451e04c419'
 $checksumType   = 'md5'
 $checksum64     = '03266a21522a86011eba965815354865'
@@ -40,9 +40,9 @@ try {
   }
 
   if ($is64bit) {
-    $zipFile = Join-Path $tempDir "zabbix_agents-$version-win-amd64-openssl.zip"
+    $zipFile = Join-Path $tempDir "zabbix_agents-$version-windows-amd64-openssl.zip"
   } else {
-    $zipFile = Join-Path $tempDir "zabbix_agents-$version-win-i386-openssl.zip"
+    $zipFile = Join-Path $tempDir "zabbix_agents-$version-windows-i386-openssl.zip"
   }
 
   Get-ChocolateyWebFile -PackageName "$id" -FileFullPath "$zipFile" -Url "$url" -Url64bit "$url64" -Checksum "$checksum" -ChecksumType "$checksumType" -Checksum64 "$checksum64" -ChecksumType64 "$checksumType64"


### PR DESCRIPTION
looks like zabbix changed the url

old url
https://assets.zabbix.com/downloads/4.4.1/zabbix_agents-4.4.1-win-amd64-openssl.zip

new url
https://assets.zabbix.com/downloads/4.4.1/zabbix_agent-4.4.1-windows-amd64-openssl.zip